### PR TITLE
Define `open-pull-requests-limit` as 10 for Node.js package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,4 @@ updates:
       include: 'scope'
     target-branch: 'main'
     versioning-strategy: 'increase'
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Resolve #45 