### PR TITLE
`convert`: Convert keys in the config JSON file into a human-friendly format before showing it in the console

### DIFF
--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -7,7 +7,12 @@ import path from 'path';
 
 import { authorize, isAuthorized } from '../auth';
 import { C2gError } from '../c2g-error';
-import { Config, CONFIG_FILE_NAME } from '../constants';
+import {
+  Config,
+  ConfigKeys,
+  CONFIG_FILE_NAME,
+  CONFIG_KEYS,
+} from '../constants';
 import { MESSAGES } from '../messages';
 import * as utils from '../utils';
 
@@ -22,6 +27,21 @@ export interface CsvFileObj {
   basename: string;
   path: string;
   existingSheetsFileId: string | null;
+}
+
+/**
+ * Convert the contents of the config object
+ * to a human-readable message string.
+ * @param config The config object
+ * @returns The human-readable message string
+ */
+export function config2message(config: Config): string {
+  return Object.keys(config)
+    .map(
+      (key) =>
+        `${CONFIG_KEYS[key as keyof ConfigKeys]}: ${config[key as keyof Config]}`,
+    )
+    .join('\n  ');
 }
 
 /**
@@ -44,11 +64,7 @@ export default async function convert(
 
   // Show message on the console
   let convertingCsvWithFollowingSettings =
-    MESSAGES.log.convertingCsvWithFollowingSettings(
-      Object.keys(config)
-        .map((key) => `${key}: ${config[key as keyof Config]}`)
-        .join('\n  '),
-    );
+    MESSAGES.log.convertingCsvWithFollowingSettings(config2message(config));
   convertingCsvWithFollowingSettings = options.dryRun
     ? `${MESSAGES.log.runningOnDryRun}\n\n${convertingCsvWithFollowingSettings}`
     : convertingCsvWithFollowingSettings;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,6 +18,13 @@ export interface Config {
   updateExistingGoogleSheets: boolean;
   saveOriginalFilesToDrive: boolean;
 }
+export interface ConfigKeys {
+  sourceDir: string;
+  targetDriveFolderId: string;
+  targetIsSharedDrive: string;
+  updateExistingGoogleSheets: string;
+  saveOriginalFilesToDrive: string;
+}
 
 // Default Config
 export const DEFAULT_CONFIG: Config = {
@@ -26,4 +33,15 @@ export const DEFAULT_CONFIG: Config = {
   targetIsSharedDrive: false,
   updateExistingGoogleSheets: false,
   saveOriginalFilesToDrive: false,
+};
+
+// Human-readable meaning of the Config keys
+export const CONFIG_KEYS: ConfigKeys = {
+  sourceDir: 'Source directory of the CSV files',
+  targetDriveFolderId: 'Target Google Drive Folder ID',
+  targetIsSharedDrive: 'Target is in a Shared Drive',
+  updateExistingGoogleSheets:
+    'Update existing Google Sheets files with the same name',
+  saveOriginalFilesToDrive:
+    'Save original CSV files to the Drive folder as well',
 };

--- a/test/constants.test.ts
+++ b/test/constants.test.ts
@@ -1,0 +1,11 @@
+// Test consistency of constants
+
+import { DEFAULT_CONFIG, CONFIG_KEYS } from '../src/constants';
+
+describe('CONFIG_KEYS', () => {
+  it('should match the keys of DEFAULT_CONFIG', () => {
+    const configKeys = Object.keys(CONFIG_KEYS);
+    const defaultConfigKeys = Object.keys(DEFAULT_CONFIG);
+    expect(configKeys).toEqual(defaultConfigKeys);
+  });
+});

--- a/test/convert.test.ts
+++ b/test/convert.test.ts
@@ -9,7 +9,7 @@ import { OAuth2Client } from 'google-auth-library';
 
 import * as auth from '../src/auth';
 import { C2gError } from '../src/c2g-error';
-import convert from '../src/commands/convert';
+import convert, { config2message } from '../src/commands/convert';
 import { Config } from '../src/constants';
 import { MESSAGES } from '../src/messages';
 import * as utils from '../src/utils';
@@ -17,6 +17,24 @@ import * as utils from '../src/utils';
 jest.mock('fs');
 jest.mock('googleapis');
 jest.mock('open');
+
+describe('config2message', () => {
+  it('should convert the config object to a human-readable message string', () => {
+    const config: Config = {
+      sourceDir: 'path/to/csv',
+      targetDriveFolderId: 'TargetDriveFolderId12345',
+      targetIsSharedDrive: true,
+      updateExistingGoogleSheets: false,
+      saveOriginalFilesToDrive: false,
+    };
+    const expectedMessage = `Source directory of the CSV files: ${config.sourceDir}
+  Target Google Drive Folder ID: ${config.targetDriveFolderId}
+  Target is in a Shared Drive: ${config.targetIsSharedDrive}
+  Update existing Google Sheets files with the same name: ${config.updateExistingGoogleSheets}
+  Save original CSV files to the Drive folder as well: ${config.saveOriginalFilesToDrive}`;
+    expect(config2message(config)).toBe(expectedMessage);
+  });
+});
 
 describe('convert', () => {
   afterEach(() => {
@@ -81,9 +99,7 @@ describe('convert', () => {
       `${
         MESSAGES.log.runningOnDryRun
       }\n\n${MESSAGES.log.convertingCsvWithFollowingSettings(
-        Object.keys(mockConfig)
-          .map((key) => `${key}: ${mockConfig[key as keyof Config]}`)
-          .join('\n  '),
+        config2message(mockConfig),
       )}`,
     );
     expect(console.info).toHaveBeenNthCalledWith(


### PR DESCRIPTION
Resolve #196